### PR TITLE
Update WendtVer

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ _Programmers are warned that the author(s) or maintainer(s) of the following sch
 
 - [Haskell Package Versioning Policy (PVP)](https://pvp.haskell.org/) <!-- 2014-04-09, ecc928d --> - An attempt to formalize the informal policy in use in the Haskell community.
 
-- [WendtVer](https://wendtver.org/) - Version numbers and the way they change convey utter chaos and no meaning about the underlying code, but are easy to figure out what the next version will be.
+- [WendtVer](https://wendtver.org/) <!-- 2017-09 --> - Version numbers and the way they change convey utter chaos and no meaning about the underlying code, but are easy to figure out what the next version will be.


### PR DESCRIPTION
Brian Wendt testified to providence in an email exchange:
> I registered the domain in Sept. 2017 and published the initial version shortly after. No access to prior versions available 😣 but you aren’t missing much as it was only typos fixed along the way. 🥴

## Requirements for your pull request

- [x] Any addition should include the date and providence (e.g. commit ID) of when it was first published.
	- ✅ `- [0-based Versioning (ZeroVer)](https://0ver.org/) <!-- 2018-03-03, f268d52 -->`

- [x] Your change should sorted in order of its publishing date within the appropriate category; if the publishing date is unknown, add it to the bottom of the appropriate category.

## Requirements for the versioning scheme

- [x] **Has been around for at least 30 days**  
  That means 30 days from either the first real commit or when it was first published. Whatever is most recent.

- [x] **Not a duplicate**  
  Please search for existing submissions.

- [x] **Be awesome**  
  This list is a curation of the best, not everything.

- [x] **Be maintained**  
  A scheme cannot be from an archived repo, deprecated, or incomplete.
